### PR TITLE
新增 set 操作方法（sadd、srem）调整测试

### DIFF
--- a/redis/cache.go
+++ b/redis/cache.go
@@ -69,3 +69,12 @@ func (c *Cache) LPop(ctx context.Context, key string) (result ecache.Value) {
 	}
 	return
 }
+
+func (c *Cache) SAdd(ctx context.Context, key string, members ...any) (int64, error) {
+	return c.client.SAdd(ctx, key, members...).Result()
+}
+
+func (c *Cache) SRem(ctx context.Context, key string, members ...any) (result ecache.Value) {
+	result.Val, result.Err = c.client.SRem(ctx, key, members...).Result()
+	return
+}

--- a/redis/cache_e2e_test.go
+++ b/redis/cache_e2e_test.go
@@ -462,8 +462,32 @@ func TestCache_e2e_SRem(t *testing.T) {
 				assert.Equal(t, int64(2), rdb.SCard(context.Background(), "test_e2e_srem").Val())
 				require.NoError(t, rdb.Del(context.Background(), "test_e2e_srem").Err())
 			},
-			key: "test_e2e_srem",
-			val: []any{"go"},
+			key:     "test_e2e_srem",
+			val:     []any{"go"},
+			wantVal: 0,
+			wantErr: nil,
+		},
+		{
+			name:    "srem e2e key nil",
+			before:  func(ctx context.Context, t *testing.T) {},
+			after:   func(ctx context.Context, t *testing.T) {},
+			key:     "test_e2e_srem",
+			val:     []any{"ecache"},
+			wantVal: 0,
+			wantErr: nil,
+		},
+		{
+			name: "srem e2e section ignore",
+			before: func(ctx context.Context, t *testing.T) {
+				require.NoError(t, rdb.SAdd(context.Background(), "test_e2e_srem", "hello", "ecache").Err())
+			},
+			after: func(ctx context.Context, t *testing.T) {
+				assert.Equal(t, int64(1), rdb.SCard(context.Background(), "test_e2e_srem").Val())
+				require.NoError(t, rdb.Del(context.Background(), "test_e2e_srem").Err())
+			},
+			key:     "test_e2e_srem",
+			val:     []any{"hello", "go"},
+			wantVal: 1,
 		},
 	}
 

--- a/redis/cache_e2e_test.go
+++ b/redis/cache_e2e_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-////go:build e2e
+//go:build e2e
 
 package redis
 

--- a/redis/cache_e2e_test.go
+++ b/redis/cache_e2e_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e
+////go:build e2e
 
 package redis
 
@@ -44,7 +44,7 @@ func TestCache_e2e_Set(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "set value",
+			name: "set e2e value",
 			after: func(ctx context.Context, t *testing.T) {
 				result, err := rdb.Get(ctx, "name").Result()
 				require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestCache_e2e_Get(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "get value",
+			name: "get e2e value",
 			before: func(ctx context.Context, t *testing.T) {
 				require.NoError(t, rdb.Set(ctx, "name", "大明", time.Minute).Err())
 			},
@@ -101,7 +101,7 @@ func TestCache_e2e_Get(t *testing.T) {
 			wantVal: "大明",
 		},
 		{
-			name:    "get error",
+			name:    "get e2e error",
 			key:     "name",
 			before:  func(ctx context.Context, t *testing.T) {},
 			after:   func(ctx context.Context, t *testing.T) {},
@@ -144,7 +144,7 @@ func TestCache_e2e_SetNX(t *testing.T) {
 		wantVal bool
 	}{
 		{
-			name:   "test setnx",
+			name:   "setnx e2e value",
 			before: func(ctx context.Context, t *testing.T) {},
 			after: func(ctx context.Context, t *testing.T) {
 				assert.NoError(t, rdb.Del(context.Background(), "testnx").Err())
@@ -154,14 +154,14 @@ func TestCache_e2e_SetNX(t *testing.T) {
 			wantVal: true,
 		},
 		{
-			name: "test setnx fail",
+			name: "setnx e2e fail",
 			before: func(ctx context.Context, t *testing.T) {
-				require.NoError(t, rdb.SetNX(ctx, "testnxf", "hello ecache", time.Minute).Err())
+				require.NoError(t, rdb.SetNX(ctx, "testnx", "hello ecache", time.Minute).Err())
 			},
 			after: func(ctx context.Context, t *testing.T) {
-				require.NoError(t, rdb.Del(ctx, "testnxf").Err())
+				require.NoError(t, rdb.Del(ctx, "testnx").Err())
 			},
-			key:     "testnxf",
+			key:     "testnx",
 			val:     "hello go",
 			wantVal: false,
 		},
@@ -199,11 +199,12 @@ func TestCache_e2e_GetSet(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "test_get_set",
+			name: "getset e2e value",
 			before: func(ctx context.Context, t *testing.T) {
 				require.NoError(t, rdb.Set(context.Background(), "test_get_set", "hello ecache", time.Second*10).Err())
 			},
 			after: func(ctx context.Context, t *testing.T) {
+				assert.Equal(t, "hello go", rdb.Get(context.Background(), "test_get_set").Val())
 				require.NoError(t, rdb.Del(context.Background(), "test_get_set").Err())
 			},
 			key:     "test_get_set",
@@ -212,15 +213,15 @@ func TestCache_e2e_GetSet(t *testing.T) {
 			wantVal: "hello ecache",
 		},
 		{
-			name:   "test_get_set",
+			name:   "getset e2e err",
 			before: func(ctx context.Context, t *testing.T) {},
 			after: func(ctx context.Context, t *testing.T) {
+				assert.Equal(t, "hello key notfound", rdb.Get(context.Background(), "test_get_set").Val())
 				require.NoError(t, rdb.Del(context.Background(), "test_get_set").Err())
 			},
 			key:     "test_get_set",
 			val:     "hello key notfound",
 			expire:  time.Second * 10,
-			wantVal: "",
 			wantErr: errs.ErrKeyNotExist,
 		},
 	}
@@ -254,7 +255,7 @@ func TestCache_e2e_LPush(t *testing.T) {
 		wantVal int64
 	}{
 		{
-			name:   "test_cache_lpush",
+			name:   "lpush e2e value",
 			before: func(ctx context.Context, t *testing.T) {},
 			after: func(ctx context.Context, t *testing.T) {
 				assert.Equal(t, int64(2), rdb.LLen(context.Background(), "test_cache_lpush").Val())
@@ -265,7 +266,7 @@ func TestCache_e2e_LPush(t *testing.T) {
 			wantVal: 2,
 		},
 		{
-			name: "test_cache_lpush_want_val",
+			name: "lpush e2e want value",
 			before: func(ctx context.Context, t *testing.T) {
 				require.NoError(t, rdb.LPush(context.Background(), "test_cache_lpush", "hello ecache", "hello go").Err())
 			},
@@ -308,7 +309,7 @@ func TestCache_e2e_LPop(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "test_cache_pop",
+			name: "lpop e2e value",
 			before: func(ctx context.Context, t *testing.T) {
 				require.NoError(t, rdb.LPush(context.Background(), "test_cache_pop", "1", "2", "3", "4").Err())
 			},
@@ -320,7 +321,7 @@ func TestCache_e2e_LPop(t *testing.T) {
 			wantVal: "4",
 		},
 		{
-			name: "test_cache_pop_one",
+			name: "lpop e2e one value",
 			before: func(ctx context.Context, t *testing.T) {
 				require.NoError(t, rdb.LPush(context.Background(), "test_cache_pop", "1").Err())
 				require.NoError(t, rdb.LPop(context.Background(), "test_cache_pop").Err())
@@ -333,7 +334,7 @@ func TestCache_e2e_LPop(t *testing.T) {
 			wantErr: errs.ErrKeyNotExist,
 		},
 		{
-			name:    "test_cache_pop_err_nil",
+			name:    "lpop e2e err",
 			before:  func(ctx context.Context, t *testing.T) {},
 			after:   func(ctx context.Context, t *testing.T) {},
 			key:     "test_cache_pop",
@@ -349,6 +350,130 @@ func TestCache_e2e_LPop(t *testing.T) {
 			c := NewCache(rdb)
 			tc.before(ctx, t)
 			val := c.LPop(ctx, tc.key)
+			assert.Equal(t, val.Val, tc.wantVal)
+			assert.Equal(t, val.Err, tc.wantErr)
+			tc.after(ctx, t)
+		})
+	}
+}
+
+func TestCache_e2e_SAdd(t *testing.T) {
+	rdb := redis.NewClient(&redis.Options{
+		Addr: "localhost:6379",
+	})
+	require.NoError(t, rdb.Ping(context.Background()).Err())
+
+	testCase := []struct {
+		name    string
+		before  func(ctx context.Context, t *testing.T)
+		after   func(ctx context.Context, t *testing.T)
+		key     string
+		val     []any
+		wantVal int64
+		wantErr error
+	}{
+		{
+			name:   "sadd e2e value",
+			before: func(ctx context.Context, t *testing.T) {},
+			after: func(ctx context.Context, t *testing.T) {
+				assert.Equal(t, int64(2), rdb.SCard(context.Background(), "test_e2e_sadd").Val())
+				require.NoError(t, rdb.Del(context.Background(), "test_e2e_sadd").Err())
+			},
+			key:     "test_e2e_sadd",
+			val:     []any{"hello ecache", "hello go"},
+			wantVal: 2,
+		},
+		{
+			name: "sadd e2e ignore",
+			before: func(ctx context.Context, t *testing.T) {
+				require.NoError(t, rdb.SAdd(context.Background(), "test_e2e_sadd", "hello").Err())
+			},
+			after: func(ctx context.Context, t *testing.T) {
+				assert.Equal(t, int64(1), rdb.SCard(context.Background(), "test_e2e_sadd").Val())
+				require.NoError(t, rdb.Del(context.Background(), "test_e2e_sadd").Err())
+			},
+			key:     "test_e2e_sadd",
+			val:     []any{"hello"},
+			wantVal: 0,
+		},
+	}
+
+	for _, tc := range testCase {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancelFunc := context.WithTimeout(context.Background(), time.Second*5)
+			defer cancelFunc()
+			c := NewCache(rdb)
+			tc.before(ctx, t)
+			val, err := c.SAdd(ctx, tc.key, tc.val...)
+			assert.Equal(t, val, tc.wantVal)
+			assert.Equal(t, err, tc.wantErr)
+			tc.after(ctx, t)
+		})
+	}
+}
+
+func TestCache_e2e_SRem(t *testing.T) {
+	rdb := redis.NewClient(&redis.Options{
+		Addr: "localhost:6379",
+	})
+	require.NoError(t, rdb.Ping(context.Background()).Err())
+
+	testCase := []struct {
+		name    string
+		before  func(ctx context.Context, t *testing.T)
+		after   func(ctx context.Context, t *testing.T)
+		key     string
+		val     []any
+		wantVal int64
+		wantErr error
+	}{
+		{
+			name: "srem e2e value",
+			before: func(ctx context.Context, t *testing.T) {
+				require.NoError(t, rdb.SAdd(context.Background(), "test_e2e_srem", "hello", "ecache").Err())
+			},
+			after: func(ctx context.Context, t *testing.T) {
+				assert.Equal(t, int64(1), rdb.SCard(context.Background(), "test_e2e_srem").Val())
+				require.NoError(t, rdb.Del(context.Background(), "test_e2e_srem").Err())
+			},
+			key:     "test_e2e_srem",
+			val:     []any{"hello"},
+			wantVal: 1,
+		},
+		{
+			name: "srem e2e nil",
+			before: func(ctx context.Context, t *testing.T) {
+				require.NoError(t, rdb.SAdd(context.Background(), "test_e2e_srem", "hello", "ecache").Err())
+				require.NoError(t, rdb.SRem(context.Background(), "test_e2e_srem", "hello", "ecache").Err())
+			},
+			after: func(ctx context.Context, t *testing.T) {
+				assert.Equal(t, int64(0), rdb.SCard(context.Background(), "test_e2e_srem").Val())
+				require.NoError(t, rdb.Del(context.Background(), "test_e2e_srem").Err())
+			},
+			key: "test_e2e_srem",
+			val: []any{"hello"},
+		},
+		{
+			name: "srem e2e ignore",
+			before: func(ctx context.Context, t *testing.T) {
+				require.NoError(t, rdb.SAdd(context.Background(), "test_e2e_srem", "hello", "ecache").Err())
+			},
+			after: func(ctx context.Context, t *testing.T) {
+				assert.Equal(t, int64(2), rdb.SCard(context.Background(), "test_e2e_srem").Val())
+				require.NoError(t, rdb.Del(context.Background(), "test_e2e_srem").Err())
+			},
+			key: "test_e2e_srem",
+			val: []any{"go"},
+		},
+	}
+
+	for _, tc := range testCase {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancelFunc := context.WithTimeout(context.Background(), time.Second*5)
+			defer cancelFunc()
+			c := NewCache(rdb)
+			tc.before(ctx, t)
+			val := c.SRem(ctx, tc.key, tc.val...)
 			assert.Equal(t, val.Val, tc.wantVal)
 			assert.Equal(t, val.Err, tc.wantErr)
 			tc.after(ctx, t)

--- a/redis/cache_test.go
+++ b/redis/cache_test.go
@@ -416,6 +416,53 @@ func TestCache_SRem(t *testing.T) {
 			val:     []any{"hello", "hello go"},
 			wantVal: 2,
 		},
+		{
+			name: "srem ignore",
+			mock: func(ctrl *gomock.Controller) redis.Cmdable {
+				cmd := mocks.NewMockCmdable(ctrl)
+				result := redis.NewIntCmd(context.Background())
+				result.SetVal(0)
+				cmd.EXPECT().
+					SRem(context.Background(), "test_srem", "hello").
+					Return(result)
+				return cmd
+			},
+			key:     "test_srem",
+			val:     []any{"hello"},
+			wantVal: 0,
+		},
+		{
+			name: "srem error",
+			mock: func(ctrl *gomock.Controller) redis.Cmdable {
+				cmd := mocks.NewMockCmdable(ctrl)
+				result := redis.NewIntCmd(context.Background())
+				result.SetVal(0)
+				result.SetErr(nil)
+				cmd.EXPECT().
+					SRem(context.Background(), "test_srem", "hello").
+					Return(result)
+				return cmd
+			},
+			key:     "test_srem",
+			val:     []any{"hello"},
+			wantVal: 0,
+			wantErr: nil,
+		},
+		{
+			name: "srem section ignore",
+			mock: func(ctrl *gomock.Controller) redis.Cmdable {
+				cmd := mocks.NewMockCmdable(ctrl)
+				result := redis.NewIntCmd(context.Background())
+				result.SetVal(1)
+				cmd.EXPECT().
+					SRem(context.Background(), "test_srem", "hello", "go").
+					Return(result)
+				return cmd
+			},
+			key:     "test_srem",
+			val:     []any{"hello", "go"},
+			wantVal: 1,
+		},
 	}
 
 	for _, tc := range testCase {

--- a/redis/cache_test.go
+++ b/redis/cache_test.go
@@ -151,7 +151,7 @@ func TestCache_SetNX(t *testing.T) {
 		result     bool
 	}{
 		{
-			name: "setnx",
+			name: "setnx value",
 			mock: func(ctrl *gomock.Controller) redis.Cmdable {
 				cmd := mocks.NewMockCmdable(ctrl)
 				boolCmd := redis.NewBoolCmd(context.Background())
@@ -167,7 +167,7 @@ func TestCache_SetNX(t *testing.T) {
 			result:     true,
 		},
 		{
-			name: "setnx-fail",
+			name: "setnx error",
 			mock: func(ctrl *gomock.Controller) redis.Cmdable {
 				cmd := mocks.NewMockCmdable(ctrl)
 				boolCmd := redis.NewBoolCmd(context.Background())
@@ -207,7 +207,7 @@ func TestCache_GetSet(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "test_get_set",
+			name: "getset value",
 			mock: func(ctrl *gomock.Controller) redis.Cmdable {
 				cmd := mocks.NewMockCmdable(ctrl)
 				str := redis.NewStringCmd(context.Background())
@@ -221,11 +221,11 @@ func TestCache_GetSet(t *testing.T) {
 			val: "hello go",
 		},
 		{
-			name: "test_get_set_err",
+			name: "getset error",
 			mock: func(ctrl *gomock.Controller) redis.Cmdable {
 				cmd := mocks.NewMockCmdable(ctrl)
 				str := redis.NewStringCmd(context.Background())
-				str.SetErr(errs.ErrKeyNotExist)
+				str.SetErr(redis.Nil)
 				cmd.EXPECT().
 					GetSet(context.Background(), "test_get_set_err", "hello ecache").
 					Return(str)
@@ -257,7 +257,7 @@ func TestCache_LPush(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "test_list_push",
+			name: "lpush value",
 			mock: func(ctrl *gomock.Controller) redis.Cmdable {
 				cmd := mocks.NewMockCmdable(ctrl)
 				result := redis.NewIntCmd(context.Background())
@@ -295,7 +295,7 @@ func TestCache_LPop(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "test_cache_lpop",
+			name: "lpop value",
 			mock: func(ctrl *gomock.Controller) redis.Cmdable {
 				cmd := mocks.NewMockCmdable(ctrl)
 				str := redis.NewStringCmd(context.Background())
@@ -309,11 +309,11 @@ func TestCache_LPop(t *testing.T) {
 			wantVal: "test",
 		},
 		{
-			name: "test_cache_lpop_err_nil",
+			name: "lpop error",
 			mock: func(ctrl *gomock.Controller) redis.Cmdable {
 				cmd := mocks.NewMockCmdable(ctrl)
 				str := redis.NewStringCmd(context.Background())
-				str.SetErr(errs.ErrKeyNotExist)
+				str.SetErr(redis.Nil)
 				cmd.EXPECT().
 					LPop(context.Background(), "test_cache_lpop").
 					Return(str)
@@ -334,6 +334,99 @@ func TestCache_LPop(t *testing.T) {
 			val := c.LPop(context.Background(), tc.key)
 			assert.Equal(t, tc.wantVal, val.Val)
 			assert.Equal(t, tc.wantErr, val.Err)
+		})
+	}
+}
+
+func TestCache_SAdd(t *testing.T) {
+	testCase := []struct {
+		name    string
+		mock    func(*gomock.Controller) redis.Cmdable
+		key     string
+		val     []any
+		wantVal int64
+		wantErr error
+	}{
+		{
+			name: "sadd value",
+			mock: func(ctrl *gomock.Controller) redis.Cmdable {
+				cmd := mocks.NewMockCmdable(ctrl)
+				result := redis.NewIntCmd(context.Background())
+				result.SetVal(2)
+				cmd.EXPECT().
+					SAdd(context.Background(), "test_sadd", "hello ecache", "hello go").
+					Return(result)
+				return cmd
+			},
+			key:     "test_sadd",
+			val:     []any{"hello ecache", "hello go"},
+			wantVal: 2,
+		},
+		{
+			name: "sadd ignore",
+			mock: func(ctrl *gomock.Controller) redis.Cmdable {
+				cmd := mocks.NewMockCmdable(ctrl)
+				result := redis.NewIntCmd(context.Background())
+				result.SetVal(1)
+				cmd.EXPECT().
+					SAdd(context.Background(), "test_sadd", "hello", "hello").
+					Return(result)
+				return cmd
+			},
+			key:     "test_sadd",
+			val:     []any{"hello", "hello"},
+			wantVal: 1,
+		},
+	}
+
+	for _, tc := range testCase {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			c := NewCache(tc.mock(ctrl))
+			length, err := c.SAdd(context.Background(), tc.key, tc.val...)
+			assert.Equal(t, length, tc.wantVal)
+			assert.Equal(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestCache_SRem(t *testing.T) {
+	testCase := []struct {
+		name    string
+		mock    func(*gomock.Controller) redis.Cmdable
+		key     string
+		val     []any
+		wantVal int64
+		wantErr error
+	}{
+		{
+			name: "srem value",
+			mock: func(ctrl *gomock.Controller) redis.Cmdable {
+				cmd := mocks.NewMockCmdable(ctrl)
+				result := redis.NewIntCmd(context.Background())
+				result.SetVal(2)
+				cmd.EXPECT().
+					SRem(context.Background(), "test_srem", "hello", "hello go").
+					Return(result)
+				return cmd
+			},
+			key:     "test_srem",
+			val:     []any{"hello", "hello go"},
+			wantVal: 2,
+		},
+	}
+
+	for _, tc := range testCase {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			c := NewCache(tc.mock(ctrl))
+			result := c.SRem(context.Background(), tc.key, tc.val...)
+			assert.Equal(t, result.Val, tc.wantVal)
+			assert.Equal(t, result.Err, tc.wantErr)
 		})
 	}
 }

--- a/types.go
+++ b/types.go
@@ -38,8 +38,12 @@ type Cache interface {
 	// 如果key不存在，则在执行推送操作之前将其创建为空列表。当key保存的值不是列表时，将返回错误
 	// 默认返回列表的数量
 	LPush(ctx context.Context, key string, val ...any) (int64, error)
-	// LPop
+	// LPop 命令用于移除并返回列表的第一个元素。
 	LPop(ctx context.Context, key string) Value
+	// SAdd 命令将一个或多个成员元素加入到集合中，已经存在于集合的成员元素将被忽略。
+	SAdd(ctx context.Context, key string, members ...any) (int64, error)
+	// SRem 移除集合中的一个或多个成员元素，不存在的成员元素会被忽略。
+	SRem(ctx context.Context, key string, members ...any) Value
 }
 
 // Value 代表一个从缓存中读取出来的值


### PR DESCRIPTION
新增redis set 相关方法

SAdd 命令将一个或多个成员元素加入到集合中，已经存在于集合的成员元素将被忽略。
SRem 移除集合中的一个或多个成员元素，不存在的成员元素会被忽略。

调整单元测试代码，提高覆盖率日益降低问题